### PR TITLE
fix for issue #1, added event recorder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,5 @@ testbin/*
 *.swp
 *.swo
 *~
+
+kind.yaml

--- a/config/samples/core_v1alpha1_sleepcycle.yaml
+++ b/config/samples/core_v1alpha1_sleepcycle.yaml
@@ -3,6 +3,6 @@ kind: SleepCycle
 metadata:
   name: sleepcycle-sample
 spec:
-  shutdown: "*/3 * * * *"
-  wakeup: "*/4 * * * *"
+  shutdown: "*/1 * * * *"
+  wakeup: "*/2 * * * *"
   enabled: true

--- a/main.go
+++ b/main.go
@@ -90,8 +90,9 @@ func main() {
 	}
 
 	if err = (&controllers.SleepCycleReconciler{
-		Client: mgr.GetClient(),
-		Scheme: mgr.GetScheme(),
+		Client:   mgr.GetClient(),
+		Scheme:   mgr.GetScheme(),
+		Recorder: mgr.GetEventRecorderFor("rekuberate-io/sleepcycles"),
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "SleepCycle")
 		os.Exit(1)


### PR DESCRIPTION
- Fixed issue that led to nil pointer dereference during reconciliation when:

1. there was no wakeup schedule defined and 
2. the reconciliation loop did not take place within the time boundaries so it is eligible to initiate a shutdown of workloads.

- Added Kubernetes Events for errors in reconciliation and in shutting down & waking up workloads.