### PR TITLE
Add the RequeueAfterSeconds and StartingDeadlineSeconds parameters to…

### DIFF
--- a/api/v1alpha1/sleepcycle_types.go
+++ b/api/v1alpha1/sleepcycle_types.go
@@ -63,6 +63,18 @@ type SleepCycleSpec struct {
 	// +kubebuilder:validation:ExclusiveMaximum=false
 	FailedJobsHistoryLimit int32 `json:"failedJobsHistoryLimit,omitempty"`
 
+	// +optional
+	// +kubebuilder:default=60
+	// +kubebuilder:validation:Type=integer
+	// +kubebuilder:validation:Minimum=10
+	RequeueAfterSeconds int32 `json:"requeueAfterSeconds,omitempty"`
+
+	// +optional
+	// +kubebuilder:default=15
+	// +kubebuilder:validation:Type=integer
+	// +kubebuilder:validation:Minimum=5
+	StartingDeadlineSeconds int64 `json:"startingDeadlineSeconds,omitempty"`
+
 	// +kubebuilder:validation:Optional
 	// +kubebuilder:default:="akyriako78/rekuberate-io-sleepcycles-runners"
 	RunnerImage string `json:"runnerImage,omitempty"`

--- a/config/crd/bases/core.rekuberate.io_sleepcycles.yaml
+++ b/config/crd/bases/core.rekuberate.io_sleepcycles.yaml
@@ -65,6 +65,11 @@ spec:
                 maximum: 3
                 minimum: 1
                 type: integer
+              requeueAfterSeconds:
+                default: 60
+                format: int32
+                minimum: 10
+                type: integer
               runnerImage:
                 default: akyriako78/rekuberate-io-sleepcycles-runners
                 type: string
@@ -74,6 +79,11 @@ spec:
               shutdownTimeZone:
                 default: UTC
                 type: string
+              startingDeadlineSeconds:
+                default: 15
+                format: int64
+                minimum: 5
+                type: integer
               successfulJobsHistoryLimit:
                 default: 0
                 format: int32

--- a/controllers/sleepcycle_controller.go
+++ b/controllers/sleepcycle_controller.go
@@ -36,9 +36,8 @@ import (
 )
 
 const (
-	SleepCycleLabel                            = "rekuberate.io/sleepcycle"
-	TimeWindowToleranceInSeconds int           = 30
-	requeueAfter                 time.Duration = 60 * time.Second
+	SleepCycleLabel            = "rekuberate.io/sleepcycle"
+	DefaultRequeueAfterSeconds = 60
 )
 
 // SleepCycleReconciler reconciles a SleepCycle object
@@ -116,6 +115,13 @@ func (r *SleepCycleReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 		r.logger.Error(err, "unable to fetch sleepcycle")
 		return ctrl.Result{}, err
 	}
+
+	rqa := original.Spec.RequeueAfterSeconds
+	if rqa == 0 {
+		rqa = DefaultRequeueAfterSeconds
+	}
+
+	requeueAfter := time.Duration(rqa) * time.Second
 
 	err := r.reconcileRbac(ctx, &original)
 	if err != nil {

--- a/controllers/sleepcycle_runners_cronjobs.go
+++ b/controllers/sleepcycle_runners_cronjobs.go
@@ -16,16 +16,13 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-var (
-	startingDeadlineSeconds int64 = 15
-)
-
 const (
-	OwnedBy        = "rekuberate.io/owned-by"
-	Target         = "rekuberate.io/target"
-	TargetKind     = "rekuberate.io/target-kind"
-	TargetTimezone = "rekuberate.io/target-tz"
-	Replicas       = "rekuberate.io/replicas"
+	OwnedBy                        = "rekuberate.io/owned-by"
+	Target                         = "rekuberate.io/target"
+	TargetKind                     = "rekuberate.io/target-kind"
+	TargetTimezone                 = "rekuberate.io/target-tz"
+	Replicas                       = "rekuberate.io/replicas"
+	DefaultStartingDeadlineSeconds = 15
 )
 
 func (r *SleepCycleReconciler) getCronJob(ctx context.Context, ownedBy, target, namespace, suffix string) (*batchv1.CronJob, error) {
@@ -73,6 +70,11 @@ func (r *SleepCycleReconciler) createCronJob(
 	if !isShutdownOp {
 		schedule = *sleepcycle.Spec.WakeUp
 		tz = sleepcycle.Spec.WakeupTimeZone
+	}
+
+	startingDeadlineSeconds := sleepcycle.Spec.StartingDeadlineSeconds
+	if startingDeadlineSeconds == 0 {
+		startingDeadlineSeconds = DefaultStartingDeadlineSeconds
 	}
 
 	labels := make(map[string]string)
@@ -253,7 +255,7 @@ func (r *SleepCycleReconciler) reconcileCronJob(
 	}
 
 	if cronjob != nil {
-		if cronjob.Status.Active != nil {
+		if len(cronjob.Status.Active) > 0 {
 			return nil
 		}
 


### PR DESCRIPTION
**Summary**

> Add configurability for reconciliation and CronJob timing in SleepCycle.

**Changes**

> - add RequeueAfterSeconds and StartingDeadlineSeconds to SleepCycle CRD
> - define defaults and validation, implement fallback logic in controller for existing resources (zero values)
> - fix CronJob active jobs check using len()

Resolves #49 